### PR TITLE
Bump module-core to 2.0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,23 +2,23 @@
   "name": "nvision/commerce365-hyva",
   "version": "2.0.4",
   "description": "Commerce 365 for Magento (Hyva Support) - Meta module",
-  "homepage" : "https://n.vision",
+  "homepage": "https://n.vision",
   "license": [
     "OSL-3.0"
   ],
   "require": {
-      "php": ">=8.2.0",
-      "magento/framework": ">=102.0.0",
-      "commerce365/module-core": ">=2.0.4",
-      "commerce365/module-customer-price": ">=2.0.10",
-      "commerce365/module-invoices": "^1.1",
-      "commerce365/module-orders": "^1.1",
-      "commerce365/module-creditmemos": "^1.1",
-      "commerce365/module-shipments": "^1.1",
-      "commerce365/module-quotes": "^1.1",
-      "commerce365/module-apiextensions": ">=1.1.2",
-      "commerce365/module-customer-price-hyva-compatibility": ">=2.0.5",
-      "commerce365/module-customer": ">=1.0.9"
+    "php": ">=8.2.0",
+    "magento/framework": ">=102.0.0",
+    "commerce365/module-core": "^2.0.6",
+    "commerce365/module-customer-price": ">=2.0.10",
+    "commerce365/module-invoices": "^1.1",
+    "commerce365/module-orders": "^1.1",
+    "commerce365/module-creditmemos": "^1.1",
+    "commerce365/module-shipments": "^1.1",
+    "commerce365/module-quotes": "^1.1",
+    "commerce365/module-apiextensions": ">=1.1.2",
+    "commerce365/module-customer-price-hyva-compatibility": ">=2.0.5",
+    "commerce365/module-customer": ">=1.0.9"
   },
   "require-dev": {
     "roave/security-advisories": "dev-latest"


### PR DESCRIPTION
Commerce365 core dependency to allow automatic 2.x updates,
Updated the Commerce365 Hyva meta-package dependency for module-core from >=2.0.4 to ^2.0.6.

Ensures new compatible module-core releases within major version 2 are picked up automatically, Dependency resolution becomes more future-proof for 2.x releases.
